### PR TITLE
~Deprecate repo and mention PagerDuty~

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# 2i2c Incident reports
+# ❗This repository is now DEPRECATED
+
+[We now use PagerDuty’s postmortem](https://team-compass.2i2c.org/projects/managed-hubs/incidents/#create-an-incident-report) feature to create the Incident Report. This lets us use notes, status updates from pagerduty as well as messages from Slack easily in the incident report!
+
+[![2i2c PagerDuty incidents](https://img.shields.io/badge/Incidents-PagerDuty-green)](https://2i2c-org.pagerduty.com/incidents)
+
+## 2i2c Incident reports
 
 The 2i2c infrastructure is constantly evolving. As people use our hubs,
 different issues often arise that result in new needs for development and


### PR DESCRIPTION
~Fixes https://github.com/2i2c-org/incident-reports/issues/5~

Repo is used to store PagerDuty reports as documentated.